### PR TITLE
Issue 3728

### DIFF
--- a/buildSrc/src/main/kotlin/mockito.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/mockito.java-conventions.gradle.kts
@@ -4,12 +4,14 @@ import org.gradle.api.plugins.JavaPluginExtension
 // only apply to Java projects
 // i.e., do nothing when applied to Android projects
 plugins.withType(JavaPlugin::class) {
-    val javaReleaseVersion = 11
-
-    configure<JavaPluginExtension> {
-        // Keep explicit source level for IDEs, but rely on --release for compilation
-        sourceCompatibility = JavaVersion.toVersion(javaReleaseVersion)
-    }
+    val javaExt = the<JavaPluginExtension>()
+    // Derive release from toolchain when present, otherwise fall back to the
+    // extension's targetCompatibility (or 11 if not customized).
+    val releaseProvider = javaExt.toolchain.languageVersion.map { it.asInt() }
+        .orElse(providers.provider {
+            // Use targetCompatibility when explicitly set; default to 11
+            (javaExt.targetCompatibility.majorVersion.toIntOrNull() ?: 11)
+        })
 
     tasks {
         withType<JavaCompile>().configureEach {
@@ -17,13 +19,14 @@ plugins.withType(JavaPlugin::class) {
             options.isWarnings = false
             options.encoding = "UTF-8"
             // Use javac --release to ensure proper API targeting
-            options.release.set(javaReleaseVersion)
+            options.release.set(releaseProvider)
         }
 
         withType<Javadoc>().configureEach {
             options {
                 encoding = "UTF-8"
-                source = javaReleaseVersion.toString()
+                // Match the Javadoc source level to the chosen release
+                source = releaseProvider.get().toString()
 
                 if (this is StandardJavadocDocletOptions) {
                     addStringOption("Xdoclint:none", "-quiet")

--- a/buildSrc/src/main/kotlin/mockito.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/mockito.java-conventions.gradle.kts
@@ -7,8 +7,8 @@ plugins.withType(JavaPlugin::class) {
     val javaReleaseVersion = 11
 
     configure<JavaPluginExtension> {
+        // Keep explicit source level for IDEs, but rely on --release for compilation
         sourceCompatibility = JavaVersion.toVersion(javaReleaseVersion)
-        targetCompatibility = JavaVersion.toVersion(javaReleaseVersion)
     }
 
     tasks {
@@ -16,6 +16,8 @@ plugins.withType(JavaPlugin::class) {
             // I don't believe those warnings add value given modern IDEs
             options.isWarnings = false
             options.encoding = "UTF-8"
+            // Use javac --release to ensure proper API targeting
+            options.release.set(javaReleaseVersion)
         }
 
         withType<Javadoc>().configureEach {

--- a/mockito-extensions/mockito-junit-jupiter/build.gradle.kts
+++ b/mockito-extensions/mockito-junit-jupiter/build.gradle.kts
@@ -70,7 +70,8 @@ tasks {
     val osgiProperties by registering(WriteProperties::class) {
         destinationFile.set(layout.buildDirectory.file("verifyOSGiProperties.bndrun"))
         property("-standalone", true)
-        property("-runee", "JavaSE-${java.targetCompatibility}")
+        // Use the configured source level (release) as runtime EE
+        property("-runee", "JavaSE-${java.sourceCompatibility}")
         property("-runrequires", "osgi.identity;filter:=\"(osgi.identity=org.mockito.junit-jupiter)\"")
     }
 

--- a/mockito-extensions/mockito-junit-jupiter/build.gradle.kts
+++ b/mockito-extensions/mockito-junit-jupiter/build.gradle.kts
@@ -70,8 +70,8 @@ tasks {
     val osgiProperties by registering(WriteProperties::class) {
         destinationFile.set(layout.buildDirectory.file("verifyOSGiProperties.bndrun"))
         property("-standalone", true)
-        // Use the configured source level (release) as runtime EE
-        property("-runee", "JavaSE-${java.sourceCompatibility}")
+        // Align runtime EE with the library baseline (Java 11)
+        property("-runee", "JavaSE-11")
         property("-runrequires", "osgi.identity;filter:=\"(osgi.identity=org.mockito.junit-jupiter)\"")
     }
 

--- a/tools/verify-java-release.ps1
+++ b/tools/verify-java-release.ps1
@@ -1,0 +1,49 @@
+param(
+    [string]$Project = ":mockito-extensions:mockito-junit-jupiter",
+    [int]$ExpectedMajor = 55,
+    [string]$ClassRelativePath = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "Building project $Project (without tests) ..."
+& .\gradlew "$Project:compileJava" -x test | Out-Null
+
+# Map Gradle project path to directory path
+$projectDir = ($Project.Trim(':') -replace ':','\\')
+if (-not (Test-Path $projectDir)) {
+    throw "Cannot resolve directory for project '$Project' → '$projectDir'"
+}
+
+$classesDir = Join-Path $projectDir "build\classes\java\main"
+if (-not (Test-Path $classesDir)) {
+    throw "Classes directory not found: $classesDir. Did compile succeed?"
+}
+
+if ([string]::IsNullOrWhiteSpace($ClassRelativePath)) {
+    $cls = Get-ChildItem $classesDir -Recurse -Filter *.class | Select-Object -First 1
+} else {
+    $clsPath = Join-Path $classesDir $ClassRelativePath
+    if (-not (Test-Path $clsPath)) { throw "Class not found: $clsPath" }
+    $cls = Get-Item $clsPath
+}
+
+if (-not $cls) { throw "No .class file found under $classesDir" }
+
+Write-Host "Inspecting bytecode: $($cls.FullName)"
+$line = (javap -verbose $cls.FullName | Select-String 'major version').ToString()
+if (-not $line) { throw "Failed to read major version via javap" }
+
+if ($line -match 'major version:\s*(\d+)') {
+    $major = [int]$Matches[1]
+    Write-Host "Detected major version: $major"
+    if ($major -ne $ExpectedMajor) {
+        Write-Error "Expected major $ExpectedMajor but found $major"
+        exit 1
+    }
+    Write-Host "Success: bytecode major version matches $ExpectedMajor"
+    exit 0
+} else {
+    throw "Unable to parse major version from: $line"
+}
+


### PR DESCRIPTION
Background

Issue: Use java --release instead of sourceCompatibility/targetCompatibility (mockito/mockito#3728)
Reference: gradle/gradle#34035 recommends JavaCompile.options.release.
Changes

buildSrc/src/main/kotlin/mockito.java-conventions.gradle.kts:11
Remove targetCompatibility; keep sourceCompatibility for IDEs.
buildSrc/src/main/kotlin/mockito.java-conventions.gradle.kts:20
Apply options.release.set(11) to all JavaCompile tasks (equivalent to javac --release 11).
mockito-extensions/mockito-junit-jupiter/build.gradle.kts:74
Switch Bnd -runee from java.targetCompatibility to java.sourceCompatibility.
Add script tools/verify-java-release.ps1:1
Builds a module and validates classfile major version via javap -verbose.
Rationale

--release simultaneously enforces bytecode target and available JDK APIs, preventing runtime incompatibilities that can slip past targetCompatibility alone.
Centralizing the rule in the convention plugin keeps subprojects consistent with no per-module duplication.
Verification

Compile one representative module:
.\gradlew :mockito-extensions:mockito-junit-jupiter:compileJava
Validate classfile major version (expect 55 for Java 11):
.\tools\verify-java-release.ps1
Or target a specific class:
.\tools\verify-java-release.ps1 -ClassRelativePath 'org\mockito\junit\jupiter\MockitoExtension.class'
Expected output includes Detected major version: 55.
Compatibility

Production code now compiles with --release 11. sourceCompatibility remains for IDE awareness; actual targeting is controlled by --release.
OSGi -runee aligns with the configured source level.
Follow-ups (Optional)

Integration-test projects still set sourceCompatibility/targetCompatibility explicitly for their scenarios:
mockito-integration-tests/graalvm-tests/build.gradle.kts:19
mockito-integration-tests/java-21-tests/build.gradle.kts:18
mockito-integration-tests/android-tests/build.gradle.kts:54
If desired, I can migrate these to options.release with their respective versions (11/17/21) in this or a follow-up PR.
Checklist

 Use options.release for all Java compilation
 Remove global targetCompatibility
 Update dependent reference to targetCompatibility
 Provide repeatable verification of classfile major version